### PR TITLE
chore: configure OIDC publishing for PyPI on release events

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write  # Needed to upload artifacts to the release
     environment:
-      name: pypi
+      name: PyPI
       url: https://pypi.org/project/airbyte-connector-models/
     # Only publish on release events (when draft releases are published)
     if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
## Summary

Configures the publish workflow to use PyPI OIDC trusted publishing, triggered when GitHub Releases are published (aligning with the release drafter workflow).

**Changes:**
- Changed publish trigger from tag-based (`startsWith(github.ref, 'refs/tags/')`) to release-based (`github.event_name == 'release' && github.event.action == 'published'`)
- Updated environment name to `PyPI` for consistency
- Fixed environment URL format (`/project/` instead of `/p/`)
- Added formal `name:` properties to all jobs and steps for better workflow readability

## Review & Testing Checklist for Human

- [ ] **Configure PyPI trusted publisher before merging**: Go to PyPI → Project Settings → Publishing → Add GitHub publisher with:
  - Repository: `airbytehq/airbyte-connector-models`
  - Workflow: `.github/workflows/publish.yml`
  - Environment: `PyPI` (must match exactly, case-sensitive)
- [ ] Verify the behavioral change is acceptable: publishing now only triggers on `release: published` events, not on direct tag pushes
- [ ] After merging, test by publishing a draft release created by release-drafter and verify the package appears on PyPI

### Notes

Since `airbyte-connector-models` doesn't exist on PyPI yet, you can use PyPI's "pending publisher" feature to pre-configure OIDC before the first publish.

**Requested by:** AJ Steers (@aaronsteers)  
**Devin session:** https://app.devin.ai/sessions/1b1da971080749a48fc0823c1c41ecd2